### PR TITLE
3.1.0.0-RC3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ ScalaTest + ScalaCheck provides integration support between ScalaTest and ScalaC
 Please use the following commands to publish to Sonatype: 
 
 ```
-$ export SCALAJS_VERSION=0.6.27
+$ export SCALAJS_VERSION=0.6.28
 $ sbt clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned scalatestPlusScalaCheckNative/publishSigned
 $ sbt ++2.10.7 clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned
 $ sbt ++2.11.12 clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned
-$ sbt ++2.13.0-RC2 clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned
+$ sbt ++2.13.0-RC3 clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned
 $ export SCALAJS_VERSION=1.0.0-M3
 $ sbt ++2.11.12 "project scalatestPlusScalaCheckJS" clean publishSigned
 $ sbt ++2.12.6 "project scalatestPlusScalaCheckJS" clean publishSigned
-$ export SCALAJS_VERSION=1.0.0-M7
-$ sbt ++2.13.0-RC2 "project scalatestPlusScalaCheckJS" clean publishSigned
+$ export SCALAJS_VERSION=1.0.0-M8
+$ sbt ++2.13.0-RC3 "project scalatestPlusScalaCheckJS" clean publishSigned
 ```

--- a/README.md
+++ b/README.md
@@ -6,14 +6,10 @@ ScalaTest + ScalaCheck provides integration support between ScalaTest and ScalaC
 Please use the following commands to publish to Sonatype: 
 
 ```
-$ export SCALAJS_VERSION=0.6.28
-$ sbt clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned scalatestPlusScalaCheckNative/publishSigned
-$ sbt ++2.10.7 clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned
-$ sbt ++2.11.12 clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned
-$ sbt ++2.13.0 clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned
-$ export SCALAJS_VERSION=1.0.0-M3
-$ sbt ++2.11.12 "project scalatestPlusScalaCheckJS" clean publishSigned
-$ sbt ++2.12.6 "project scalatestPlusScalaCheckJS" clean publishSigned
+$ export SCALAJS_VERSION=0.6.29
+$ sbt clean +scalatestPlusScalaCheckJS/publishSigned +scalatestPlusScalaCheckJVM/publishSigned scalatestPlusScalaCheckNative/publishSigned
 $ export SCALAJS_VERSION=1.0.0-M8
-$ sbt ++2.13.0 "project scalatestPlusScalaCheckJS" clean publishSigned
+$ sbt ++2.11.12 "project scalatestPlusScalaCheckJS" clean publishSigned
+$ sbt ++2.12.10 "project scalatestPlusScalaCheckJS" clean publishSigned
+$ sbt ++2.13.1 "project scalatestPlusScalaCheckJS" clean publishSigned
 ```

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ $ export SCALAJS_VERSION=0.6.28
 $ sbt clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned scalatestPlusScalaCheckNative/publishSigned
 $ sbt ++2.10.7 clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned
 $ sbt ++2.11.12 clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned
-$ sbt ++2.13.0-RC3 clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned
+$ sbt ++2.13.0 clean scalatestPlusScalaCheckJS/publishSigned scalatestPlusScalaCheckJVM/publishSigned
 $ export SCALAJS_VERSION=1.0.0-M3
 $ sbt ++2.11.12 "project scalatestPlusScalaCheckJS" clean publishSigned
 $ sbt ++2.12.6 "project scalatestPlusScalaCheckJS" clean publishSigned
 $ export SCALAJS_VERSION=1.0.0-M8
-$ sbt ++2.13.0-RC3 "project scalatestPlusScalaCheckJS" clean publishSigned
+$ sbt ++2.13.0 "project scalatestPlusScalaCheckJS" clean publishSigned
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalanative.sbtplugin.ScalaNativePluginInternal.NativeTest
 val sharedSettings = Seq(
   name := "scalatestplus-scalacheck",
   organization := "org.scalatestplus",
-  version := "1.0.0-M1",
+  version := "1.0.0-M2",
   homepage := Some(url("https://github.com/scalatest/scalatestplus-scalacheck")),
   licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   developers := List(
@@ -23,7 +23,7 @@ val sharedSettings = Seq(
   ),
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest" % "3.1.0-M1"
+    "org.scalatest" %%% "scalatest" % "3.1.0-M2"
   ),
   sourceGenerators in Compile += {
     Def.task {

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalanative.sbtplugin.ScalaNativePluginInternal.NativeTest
 val sharedSettings = Seq(
   name := "scalatestplus-scalacheck",
   organization := "org.scalatestplus",
-  version := "1.0.0-M2",
+  version := "3.1.0.0-RC2",
   homepage := Some(url("https://github.com/scalatest/scalatestplus-scalacheck")),
   licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   developers := List(
@@ -23,7 +23,7 @@ val sharedSettings = Seq(
   ),
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest" % "3.1.0-M2"
+    "org.scalatest" %%% "scalatest" % "3.1.0-RC2"
   ),
   sourceGenerators in Compile += {
     Def.task {
@@ -71,7 +71,7 @@ lazy val scalatestPlusScalaCheck =
       )
     )
     .jsSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0"),
+      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.9", "2.13.0"),
       libraryDependencies ++= Seq(
         "org.scalacheck" %%% "scalacheck" % "1.14.0"
       ), 
@@ -83,7 +83,7 @@ lazy val scalatestPlusScalaCheck =
       }
     )
     .jvmSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0"),
+      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.9", "2.13.0"),
       libraryDependencies ++= Seq(
         "org.scalacheck" %%% "scalacheck" % "1.14.0"
       ), 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalanative.sbtplugin.ScalaNativePluginInternal.NativeTest
 val sharedSettings = Seq(
   name := "scalatestplus-scalacheck",
   organization := "org.scalatestplus",
-  version := "1.0.0-SNAP6",
+  version := "1.0.0-SNAP7",
   homepage := Some(url("https://github.com/scalatest/scalatestplus-scalacheck")),
   licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   developers := List(
@@ -23,7 +23,7 @@ val sharedSettings = Seq(
   ),
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest" % "3.1.0-SNAP11"
+    "org.scalatest" %%% "scalatest" % "3.1.0-SNAP12"
   ),
   sourceGenerators in Compile += {
     Def.task {
@@ -71,7 +71,7 @@ lazy val scalatestPlusScalaCheck =
       )
     )
     .jsSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0-RC2"),
+      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0-RC3"),
       libraryDependencies ++= Seq(
         "org.scalacheck" %%% "scalacheck" % "1.14.0"
       ), 
@@ -83,7 +83,7 @@ lazy val scalatestPlusScalaCheck =
       }
     )
     .jvmSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0-RC2"),
+      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0-RC3"),
       libraryDependencies ++= Seq(
         "org.scalacheck" %%% "scalacheck" % "1.14.0"
       ), 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 import scalanative.sbtplugin.ScalaNativePluginInternal.NativeTest
 
 val sharedSettings = Seq(
-  name := "scalatestplus-scalacheck",
+  name := "scalacheck-1.14",
   organization := "org.scalatestplus",
   version := "3.1.0.0-RC2",
   homepage := Some(url("https://github.com/scalatest/scalatestplus-scalacheck")),

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalanative.sbtplugin.ScalaNativePluginInternal.NativeTest
 val sharedSettings = Seq(
   name := "scalatestplus-scalacheck",
   organization := "org.scalatestplus",
-  version := "1.0.0-SNAP7",
+  version := "1.0.0-SNAP8",
   homepage := Some(url("https://github.com/scalatest/scalatestplus-scalacheck")),
   licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   developers := List(
@@ -23,7 +23,7 @@ val sharedSettings = Seq(
   ),
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest" % "3.1.0-SNAP12"
+    "org.scalatest" %%% "scalatest" % "3.1.0-SNAP13"
   ),
   sourceGenerators in Compile += {
     Def.task {
@@ -71,7 +71,7 @@ lazy val scalatestPlusScalaCheck =
       )
     )
     .jsSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0-RC3"),
+      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0"),
       libraryDependencies ++= Seq(
         "org.scalacheck" %%% "scalacheck" % "1.14.0"
       ), 
@@ -83,7 +83,7 @@ lazy val scalatestPlusScalaCheck =
       }
     )
     .jvmSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0-RC3"),
+      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0"),
       libraryDependencies ++= Seq(
         "org.scalacheck" %%% "scalacheck" % "1.14.0"
       ), 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalanative.sbtplugin.ScalaNativePluginInternal.NativeTest
 val sharedSettings = Seq(
   name := "scalatestplus-scalacheck",
   organization := "org.scalatestplus",
-  version := "1.0.0-SNAP8",
+  version := "1.0.0-M1",
   homepage := Some(url("https://github.com/scalatest/scalatestplus-scalacheck")),
   licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   developers := List(
@@ -23,7 +23,7 @@ val sharedSettings = Seq(
   ),
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest" % "3.1.0-SNAP13"
+    "org.scalatest" %%% "scalatest" % "3.1.0-M1"
   ),
   sourceGenerators in Compile += {
     Def.task {

--- a/build.sbt
+++ b/build.sbt
@@ -71,9 +71,9 @@ lazy val scalatestPlusScalaCheck =
       )
     )
     .jsSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.0"),
+      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.1"),
       libraryDependencies ++= Seq(
-        "org.scalacheck" %%% "scalacheck" % "1.14.0"
+        "org.scalacheck" %%% "scalacheck" % "1.14.1"
       ), 
       sourceGenerators in Compile += {
         Def.task {
@@ -83,9 +83,9 @@ lazy val scalatestPlusScalaCheck =
       }
     )
     .jvmSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.0"),
+      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.1"),
       libraryDependencies ++= Seq(
-        "org.scalacheck" %%% "scalacheck" % "1.14.0"
+        "org.scalacheck" %%% "scalacheck" % "1.14.1"
       ), 
       sourceGenerators in Compile += {
         Def.task {
@@ -98,7 +98,7 @@ lazy val scalatestPlusScalaCheck =
       scalaVersion := "2.11.12", 
       nativeLinkStubs in NativeTest := true, 
       libraryDependencies ++= Seq(
-        "org.scalacheck" %%% "scalacheck" % "1.14.1-86bd34e-SNAPSHOT"
+        "org.scalacheck" %%% "scalacheck" % "1.14.1"
       ), 
       sourceGenerators in Compile += {
         Def.task {

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalanative.sbtplugin.ScalaNativePluginInternal.NativeTest
 val sharedSettings = Seq(
   name := "scalacheck-1.14",
   organization := "org.scalatestplus",
-  version := "3.1.0.0-RC2",
+  version := "3.1.0.0-RC3",
   homepage := Some(url("https://github.com/scalatest/scalatestplus-scalacheck")),
   licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   developers := List(
@@ -23,7 +23,7 @@ val sharedSettings = Seq(
   ),
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest" % "3.1.0-RC2"
+    "org.scalatest" %%% "scalatest" % "3.1.0-RC3"
   ),
   sourceGenerators in Compile += {
     Def.task {
@@ -71,7 +71,7 @@ lazy val scalatestPlusScalaCheck =
       )
     )
     .jsSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.9", "2.13.0"),
+      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.0"),
       libraryDependencies ++= Seq(
         "org.scalacheck" %%% "scalacheck" % "1.14.0"
       ), 
@@ -83,7 +83,7 @@ lazy val scalatestPlusScalaCheck =
       }
     )
     .jvmSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.9", "2.13.0"),
+      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.0"),
       libraryDependencies ++= Seq(
         "org.scalacheck" %%% "scalacheck" % "1.14.0"
       ), 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,11 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
 
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.28")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.29")
 
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % scalaJSVersion)
 
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.8")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.0-M2")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
 
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.27")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.28")
 
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % scalaJSVersion)
 

--- a/scalatestPlusScalaCheck/src/main/scala/org/scalatestplus/scalacheck/ScalaCheckGenerators.scala
+++ b/scalatestPlusScalaCheck/src/main/scala/org/scalatestplus/scalacheck/ScalaCheckGenerators.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatestplus.scalacheck
+/*package org.scalatestplus.scalacheck
 
 import org.scalatest.prop.{Generator, Randomizer, SizeParam}
 
@@ -42,3 +42,4 @@ trait ScalaCheckGenerators {
 }
 
 object ScalaCheckGenerators extends ScalaCheckGenerators 
+*/

--- a/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/ScalaCheckGeneratorsSpec.scala
+++ b/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/ScalaCheckGeneratorsSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.scalatestplus.scalacheck
+/*package org.scalatestplus.scalacheck
 
 import org.scalacheck._
 import org.scalatest._
@@ -59,5 +59,5 @@ class ScalaCheckGeneratorsSpec extends funspec.AnyFunSpec with PropertyChecks {
     val scalaTestShrinkList = scalaTestShrinkIt.toList
     scalaTestShrinkList shouldEqual scalaCheckShrinkList.reverse
   }
-}
+}*/
 


### PR DESCRIPTION
Adjustments for 3.1.0.0-RC3 release, which uses ScalaTest 3.1.0-RC3.