### PR TITLE
ScalaCheck 1.14.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,9 @@ lazy val scalatestPlusScalaCheck =
     .settings(sharedSettings)
     .enablePlugins(SbtOsgi)
     .settings(osgiSettings: _*).settings(
+      libraryDependencies ++= Seq(
+        "org.scalacheck" %%% "scalacheck" % "1.14.2"
+      ), 
       OsgiKeys.exportPackage := Seq(
         "org.scalatestplus.scalacheck.*"
       ),
@@ -89,9 +92,6 @@ lazy val scalatestPlusScalaCheck =
     )
     .jsSettings(
       crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.1"),
-      libraryDependencies ++= Seq(
-        "org.scalacheck" %%% "scalacheck" % "1.14.1"
-      ), 
       sourceGenerators in Compile += {
         Def.task {
           GenResourcesJSVM.genResources((sourceManaged in Compile).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++
@@ -101,9 +101,6 @@ lazy val scalatestPlusScalaCheck =
     )
     .jvmSettings(
       crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.1"),
-      libraryDependencies ++= Seq(
-        "org.scalacheck" %%% "scalacheck" % "1.14.1"
-      ), 
       sourceGenerators in Compile += {
         Def.task {
           GenResourcesJVM.genResources((sourceManaged in Compile).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++
@@ -114,9 +111,6 @@ lazy val scalatestPlusScalaCheck =
     .nativeSettings(
       scalaVersion := "2.11.12", 
       nativeLinkStubs in NativeTest := true, 
-      libraryDependencies ++= Seq(
-        "org.scalacheck" %%% "scalacheck" % "1.14.1"
-      ), 
       sourceGenerators in Compile += {
         Def.task {
           GenResourcesJSVM.genResources((sourceManaged in Compile).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalanative.sbtplugin.ScalaNativePluginInternal.NativeTest
 val sharedSettings = Seq(
   name := "scalacheck-1.14",
   organization := "org.scalatestplus",
-  version := "3.1.0.0-RC3",
+  version := "3.2.0.0-M1",
   homepage := Some(url("https://github.com/scalatest/scalatestplus-scalacheck")),
   licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   developers := List(
@@ -23,7 +23,10 @@ val sharedSettings = Seq(
   ),
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest" % "3.1.0-RC3"
+    "org.scalatest" %%% "scalatest-core" % "3.2.0-M1", 
+    "org.scalatest" %%% "scalatest-shouldmatchers" % "3.2.0-M1" % "test", 
+    "org.scalatest" %%% "scalatest-funspec" % "3.2.0-M1" % "test",
+    "org.scalatest" %%% "scalatest-funsuite" % "3.2.0-M1" % "test"
   ),
   sourceGenerators in Compile += {
     Def.task {

--- a/project/GenScalaCheckGen.scala
+++ b/project/GenScalaCheckGen.scala
@@ -1104,7 +1104,7 @@ object ScalaCheckDrivenPropertyChecks extends ScalaCheckDrivenPropertyChecks
 
   val generatorSuitePreamble = """
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
 import org.scalacheck.Gen
                                """

--- a/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/CheckersSpec.scala
+++ b/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/CheckersSpec.scala
@@ -19,7 +19,7 @@ import org.scalacheck._
 import org.scalatest._
 import Arbitrary._
 import Prop._
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
 import org.scalacheck.util.Pretty
 import org.scalatest.exceptions.TestFailedException

--- a/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/PropertyCheckConfigurationHelperSuite.scala
+++ b/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/PropertyCheckConfigurationHelperSuite.scala
@@ -18,7 +18,7 @@ package scalacheck
 
 import org.scalactic.anyvals._
 
-class PropertyCheckConfigurationHelperSuite extends org.scalatest.funsuite.AnyFunSuite with org.scalatest.Matchers {
+class PropertyCheckConfigurationHelperSuite extends org.scalatest.funsuite.AnyFunSuite with org.scalatest.matchers.should.Matchers {
 
   import org.scalatestplus.scalacheck.ScalaCheckConfiguration._
 


### PR DESCRIPTION
Bumped up ScalaCheck version number to 1.14.2.

Note: This PR branch is branched off from 3.2.0-M1 branch.