### PR TITLE
[3.1] ScalaCheck 1.14.3 + Scala-js 1.0.0-RC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ ScalaTest + ScalaCheck provides integration support between ScalaTest and ScalaC
 Please use the following commands to publish to Sonatype: 
 
 ```
-$ export SCALAJS_VERSION=0.6.29
+$ export SCALAJS_VERSION=0.6.31
 $ sbt clean +scalatestPlusScalaCheckJS/publishSigned +scalatestPlusScalaCheckJVM/publishSigned scalatestPlusScalaCheckNative/publishSigned
-$ export SCALAJS_VERSION=1.0.0-M8
+$ export SCALAJS_VERSION=1.0.0-RC2
 $ sbt ++2.11.12 "project scalatestPlusScalaCheckJS" clean publishSigned
 $ sbt ++2.12.10 "project scalatestPlusScalaCheckJS" clean publishSigned
 $ sbt ++2.13.1 "project scalatestPlusScalaCheckJS" clean publishSigned

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scalanative.sbtplugin.ScalaNativePluginInternal.NativeTest
 val sharedSettings = Seq(
   name := "scalacheck-1.14",
   organization := "org.scalatestplus",
-  version := "3.1.0.0-RC3",
+  version := "3.1.0.1",
   homepage := Some(url("https://github.com/scalatest/scalatestplus-scalacheck")),
   licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   developers := List(
@@ -23,7 +23,8 @@ val sharedSettings = Seq(
   ),
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest" % "3.1.0-RC3"
+    "org.scalatest" %%% "scalatest" % "3.1.0", 
+    "org.scalacheck" %%% "scalacheck" % "1.14.3"
   ),
   sourceGenerators in Compile += {
     Def.task {
@@ -72,9 +73,7 @@ lazy val scalatestPlusScalaCheck =
     )
     .jsSettings(
       crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.1"),
-      libraryDependencies ++= Seq(
-        "org.scalacheck" %%% "scalacheck" % "1.14.1"
-      ), 
+      
       sourceGenerators in Compile += {
         Def.task {
           GenResourcesJSVM.genResources((sourceManaged in Compile).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++
@@ -84,9 +83,6 @@ lazy val scalatestPlusScalaCheck =
     )
     .jvmSettings(
       crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.1"),
-      libraryDependencies ++= Seq(
-        "org.scalacheck" %%% "scalacheck" % "1.14.1"
-      ), 
       sourceGenerators in Compile += {
         Def.task {
           GenResourcesJVM.genResources((sourceManaged in Compile).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++
@@ -97,9 +93,6 @@ lazy val scalatestPlusScalaCheck =
     .nativeSettings(
       scalaVersion := "2.11.12", 
       nativeLinkStubs in NativeTest := true, 
-      libraryDependencies ++= Seq(
-        "org.scalacheck" %%% "scalacheck" % "1.14.1"
-      ), 
       sourceGenerators in Compile += {
         Def.task {
           GenResourcesJSVM.genResources((sourceManaged in Compile).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
 
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.29")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.31")
 
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % scalaJSVersion)
 


### PR DESCRIPTION
Bumped up to use ScalaCheck 1.14.3 and Scala-js 1.0.0-RC2.