### PR TITLE
Release for ScalaCheck 1.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,12 +23,12 @@ val sharedSettings = Seq(
       url("https://github.com/cheeseng")
     )
   ),
-  resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots", 
+  resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest-core" % "3.2.2", 
-    ("org.scalacheck" %%% "scalacheck" % "1.14.3").withDottyCompat(scalaVersion.value), 
-    "org.scalatest" %%% "scalatest-shouldmatchers" % "3.2.2" % "test", 
-    "org.scalatest" %%% "scalatest-funspec" % "3.2.2" % "test", 
+    "org.scalatest" %%% "scalatest-core" % "3.2.2",
+    "org.scalacheck" %%% "scalacheck" % "1.15.0",
+    "org.scalatest" %%% "scalatest-shouldmatchers" % "3.2.2" % "test",
+    "org.scalatest" %%% "scalatest-funspec" % "3.2.2" % "test",
     "org.scalatest" %%% "scalatest-funsuite" % "3.2.2" % "test"
   ),
   // skip dependency elements with a scope
@@ -42,7 +42,7 @@ val sharedSettings = Seq(
         case _ => node
       }
     }).transform(node).head
-  }, 
+  },
   sourceGenerators in Compile += {
     Def.task {
       GenScalaCheckGen.genMain((sourceManaged in Compile).value / "org" / "scalatest" / "check", version.value, scalaVersion.value)
@@ -52,7 +52,7 @@ val sharedSettings = Seq(
     Def.task {
       GenScalaCheckGen.genTest((sourceManaged in Test).value / "org" / "scalatest" / "check", version.value, scalaVersion.value)
     }
-  }, 
+  },
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     Some("publish-releases" at nexus + "service/local/staging/deploy/maven2")
@@ -68,8 +68,8 @@ val sharedSettings = Seq(
         scm:git:git@github.com:scalatest/scalatestplus-scalacheck.git
       </developerConnection>
     </scm>
-  ),  
-  credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"), 
+  ),
+  credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
   scalacOptions in (Compile, doc) := Seq("-doc-title", s"ScalaTest + ScalaCheck ${version.value}")
 )
 
@@ -85,7 +85,7 @@ lazy val scalatestPlusScalaCheck =
       ),
       OsgiKeys.importPackage := Seq(
         "org.scalatest.*",
-        "org.scalactic.*", 
+        "org.scalactic.*",
         "scala.*;version=\"$<range;[==,=+);$<replace;"+scalaBinaryVersion.value+";-;.>>\"",
         "*;resolution:=optional"
       ),
@@ -97,7 +97,7 @@ lazy val scalatestPlusScalaCheck =
       )
     )
     .jsSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.12", "2.13.3"),
+      crossScalaVersions := List("2.11.12", "2.12.12", "2.13.3"),
       sourceGenerators in Compile += {
         Def.task {
           GenResourcesJSVM.genResources((sourceManaged in Compile).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++
@@ -106,8 +106,8 @@ lazy val scalatestPlusScalaCheck =
       }
     )
     .jvmSettings(
-      crossScalaVersions := List("2.10.7", "2.11.12", "2.12.12", "2.13.3", "0.27.0-RC1"),
-      Test / scalacOptions ++= (if (isDotty.value) Seq("-language:implicitConversions") else Nil), 
+      crossScalaVersions := List("2.11.12", "2.12.12", "2.13.3", "0.27.0-RC1"),
+      Test / scalacOptions ++= (if (isDotty.value) Seq("-language:implicitConversions") else Nil),
       sourceGenerators in Compile += {
         Def.task {
           GenResourcesJVM.genResources((sourceManaged in Compile).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++
@@ -116,8 +116,8 @@ lazy val scalatestPlusScalaCheck =
       }
     )
     .nativeSettings(
-      scalaVersion := "2.11.12", 
-      nativeLinkStubs in NativeTest := true, 
+      scalaVersion := "2.11.12",
+      nativeLinkStubs in NativeTest := true,
       sourceGenerators in Compile += {
         Def.task {
           GenResourcesJSVM.genResources((sourceManaged in Compile).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,18 @@ val sharedSettings = Seq(
     </scm>
   ),
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
-  scalacOptions in (Compile, doc) := Seq("-doc-title", s"ScalaTest + ScalaCheck ${version.value}")
+  scalacOptions in (Compile, doc) := {
+    if (scalaBinaryVersion.value startsWith "0.2") 
+      Seq.empty
+    else
+      Seq("-doc-title", s"ScalaTest + ScalaCheck ${version.value}")
+  }, 
+  publishArtifact in (Compile, packageDoc) := {
+    if (scalaBinaryVersion.value startsWith "0.2")
+      false // Temporary disable publishing of doc in dotty, can't get it to build.
+    else
+      true  
+  }
 )
 
 lazy val scalatestPlusScalaCheck =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
 
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.2.0")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.3.0")
 
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % scalaJSVersion)
 


### PR DESCRIPTION
This PR includes changes from https://github.com/scalatest/scalatestplus-scalacheck/pull/41, plus a tweak to get the publishing working.