### PR TITLE
ScalaTest Seed Argument (-S) Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,11 +68,11 @@ val sharedSettings = Seq(
   ),
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   libraryDependencies ++= Seq(
-    "org.scalatest" %%% "scalatest-core" % "3.2.11",
+    "org.scalatest" %%% "scalatest-core" % "3.2.12-RC1",
     "org.scalacheck" %%% "scalacheck" % "1.15.4",
-    "org.scalatest" %%% "scalatest-shouldmatchers" % "3.2.11" % "test",
-    "org.scalatest" %%% "scalatest-funspec" % "3.2.11" % "test",
-    "org.scalatest" %%% "scalatest-funsuite" % "3.2.11" % "test"
+    "org.scalatest" %%% "scalatest-shouldmatchers" % "3.2.12-RC1" % "test",
+    "org.scalatest" %%% "scalatest-funspec" % "3.2.12-RC1" % "test",
+    "org.scalatest" %%% "scalatest-funsuite" % "3.2.12-RC1" % "test"
   ),
   // skip dependency elements with a scope
   pomPostProcess := { (node: XmlNode) =>

--- a/scalatestPlusScalaCheck/.jvm/src/main/resources/org/scalatestplus/scalacheck/MessageBundle.properties
+++ b/scalatestPlusScalaCheck/.jvm/src/main/resources/org/scalatestplus/scalacheck/MessageBundle.properties
@@ -10,3 +10,4 @@ occurredOnValues=Occurred when passed generated values (
 thrownExceptionsMessage=Message: {0}
 bigProblems=An exception or error caused a run to abort. 
 bigProblemsWithMessage=An exception or error caused a run to abort: {0} 
+initSeed=Init Seed: {0}

--- a/scalatestPlusScalaCheck/src/main/scala/org/scalatestplus/scalacheck/ScalaCheckConfiguration.scala
+++ b/scalatestPlusScalaCheck/src/main/scala/org/scalatestplus/scalacheck/ScalaCheckConfiguration.scala
@@ -77,6 +77,12 @@ private[scalacheck] trait ScalaCheckConfiguration extends Configuration {
 
     val maxDiscardRatio: Float = maxDiscardedFactor.getOrElse(config.maxDiscardedFactor.value).toFloat
 
+    val seed =
+      org.scalatest.prop.Seed.configured match {
+        case Some(s) => org.scalacheck.rng.Seed.fromLongs(0xf1ea5eed, s.value, s.value, s.value)
+        case None => org.scalacheck.rng.Seed.random()
+      }
+
     Parameters.default
       .withMinSuccessfulTests(minSuccessfulTests)
       .withMinSize(minSize)
@@ -85,6 +91,7 @@ private[scalacheck] trait ScalaCheckConfiguration extends Configuration {
       .withTestCallback(new TestCallback {})
       .withMaxDiscardRatio(maxDiscardRatio)
       .withCustomClassLoader(None)
+      .withInitialSeed(seed)
   }
 
 }


### PR DESCRIPTION
- Show Init Seed in error message when test fails.
- Use init seed specified by -S ScalaTest argument which is resurrected in https://github.com/scalatest/scalatest/pull/2104 .