### PR TITLE
Fix Prettifier Not Used by Property Checks

### DIFF
--- a/project/GenResources.scala
+++ b/project/GenResources.scala
@@ -198,7 +198,7 @@ object GenResourcesJSVM extends GenResources {
         |
         |private[$packageName] object FailureMessages {
         |
-        |def decorateToStringValue(prettifier: org.scalactic.Prettifier, o: Any): String = org.scalactic.Prettifier.default(o)
+        |def decorateToStringValue(prettifier: org.scalactic.Prettifier, o: Any): String = prettifier.apply(o)
         |
         |$methods
         |

--- a/scalatestPlusScalaCheck/src/main/scala/org/scalatestplus/scalacheck/CheckerAsserting.scala
+++ b/scalatestPlusScalaCheck/src/main/scala/org/scalatestplus/scalacheck/CheckerAsserting.scala
@@ -15,13 +15,15 @@
  */
 package org.scalatestplus.scalacheck
 
-import org.scalactic.{Resources => _, FailureMessages => _, UnquotedString => _, _}
+import org.scalactic.{FailureMessages => _, Resources => _, UnquotedString => _, _}
 import NameUtil.getSimpleNameOfAnObjectsClass
 import org.scalacheck.Prop
 import org.scalacheck.Prop.Arg
 import org.scalacheck.Test
 import org.scalacheck.util.Pretty
 import org.scalatest.Assertion
+
+import scala.collection.mutable
 //import org.scalatest.Expectation
 import org.scalatest.Fact
 import org.scalatest.Succeeded
@@ -331,6 +333,14 @@ object CheckerAsserting extends ExpectationCheckerAsserting {
       case _: String    => decorateToStringValue(prettifier, arg.arg)
       case _: Char      => decorateToStringValue(prettifier, arg.arg)
       case _: Array[_]  => decorateToStringValue(prettifier, arg.arg)
+      case _: mutable.WrappedArray[_]  => decorateToStringValue(prettifier, arg.arg)
+      case a if ArrayHelper.isArrayOps(arg.arg) => decorateToStringValue(prettifier, arg.arg)
+      case _: Many[_]  => decorateToStringValue(prettifier, arg.arg)
+      case _: scala.collection.GenMap[_, _]  => decorateToStringValue(prettifier, arg.arg)
+      case _: Iterable[_]  => decorateToStringValue(prettifier, arg.arg)
+      case _: java.util.Collection[_]  => decorateToStringValue(prettifier, arg.arg)
+      case _: java.util.Map[_, _]  => decorateToStringValue(prettifier, arg.arg)
+      case p: Product if p.productArity > 0  => decorateToStringValue(prettifier, arg.arg)
       case _            => arg.prettyArg(new Pretty.Params(0))
     }
 

--- a/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/ScalaCheckDrivenPropertyChecksSpec.scala
+++ b/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/ScalaCheckDrivenPropertyChecksSpec.scala
@@ -41,8 +41,6 @@ class ScalaCheckDrivenPropertyChecksSpec extends funspec.AnyFunSpec with ScalaCh
         }
 
       assert(e.getMessage().contains("List(" + failingList.take(2).mkString(", ") + ", ...)"))
-
-      println("###debug: " + e.getMessage())
     }
   }
 

--- a/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/ScalaCheckDrivenPropertyChecksSpec.scala
+++ b/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/ScalaCheckDrivenPropertyChecksSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2001-2022 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.scalacheck
+
+import org.scalacheck.Gen
+import org.scalactic.{Prettifier, SizeLimit}
+import org.scalatest._
+import org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException
+
+class ScalaCheckDrivenPropertyChecksSpec extends funspec.AnyFunSpec with ScalaCheckDrivenPropertyChecks {
+
+  describe("ScalaCheckDrivnePropertyChecks") {
+    it("should truncate argument using passed in Prettifier") {
+      val listGen: Gen[List[Int]] = {
+        val gens = List(Gen.chooseNum(1, 2), Gen.chooseNum(3, 4), Gen.chooseNum(5, 6))
+        Gen.sequence[List[Int], Int](gens)
+      }
+
+      var failingList: List[Int] = null
+      implicit val prettifer = Prettifier.truncateAt(SizeLimit(2))
+
+      val e =
+        intercept[GeneratorDrivenPropertyCheckFailedException] {
+          forAll(listGen) { list =>
+            failingList = list
+            assert(list.length != 3)
+          }
+        }
+
+      assert(e.getMessage().contains("List(" + failingList.take(2).mkString(", ") + ", ...)"))
+
+      println("###debug: " + e.getMessage())
+    }
+  }
+
+}


### PR DESCRIPTION
This PR is built on top of https://github.com/scalatest/scalatestplus-scalacheck/pull/57 , this fixes problem reported in https://github.com/scalatest/scalatest/issues/2174 .