### PR TITLE
Use `Seed.fromLongs` for initial seed

### DIFF
--- a/scalatestPlusScalaCheck/src/main/scala/org/scalatestplus/scalacheck/ScalaCheckConfiguration.scala
+++ b/scalatestPlusScalaCheck/src/main/scala/org/scalatestplus/scalacheck/ScalaCheckConfiguration.scala
@@ -77,11 +77,10 @@ private[scalacheck] trait ScalaCheckConfiguration extends Configuration {
 
     val maxDiscardRatio: Float = maxDiscardedFactor.getOrElse(config.maxDiscardedFactor.value).toFloat
 
-    val seed =
-      org.scalatest.prop.Seed.configured match {
-        case Some(s) => org.scalacheck.rng.Seed.fromLongs(0xf1ea5eed, s.value, s.value, s.value)
-        case None => org.scalacheck.rng.Seed.random()
-      }
+    val seed = {
+      val s = org.scalatest.prop.Seed.configured.fold(scala.util.Random.nextLong)(_.value)
+      org.scalacheck.rng.Seed.fromLongs(0xf1ea5eed, s, s, s)
+    }
 
     Parameters.default
       .withMinSuccessfulTests(minSuccessfulTests)


### PR DESCRIPTION
`Seed.random()` internally calls `Seed.next` a few times, which makes the error message (e.g. `Init Seed: -629881034477878617`) not very useful for recreating the seed, as we don't know the other 3 numbers.