### PR TITLE
ScalaCheck, Scala JS + Native Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ ScalaTest + ScalaCheck provides integration support between ScalaTest and ScalaC
 
 **Usage**
 
-To use it for ScalaTest 3.2.18 and ScalaCheck 1.17.x: 
+To use it for ScalaTest 3.2.18 and ScalaCheck 1.18.x: 
 
 SBT: 
 
 ```
-libraryDependencies += "org.scalatestplus" %% "scalacheck-1-17" % "3.2.18.0" % "test"
+libraryDependencies += "org.scalatestplus" %% "scalacheck-1-18" % "3.2.18.0" % "test"
 ```
 
 Maven: 
@@ -16,7 +16,7 @@ Maven:
 ```
 <dependency>
   <groupId>org.scalatestplus</groupId>
-  <artifactId>scalacheck-1-17_2.13</artifactId>
+  <artifactId>scalacheck-1-18_2.13</artifactId>
   <version>3.2.18.0</version>
   <scope>test</scope>
 </dependency>

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ def docTask(docDir: File, resDir: File, projectName: String): File = {
 }
 
 val sharedSettings = Seq(
-  name := "scalacheck-1.17",
+  name := "scalacheck-1.18",
   organization := "org.scalatestplus",
   version := "3.2.18.0",
   homepage := Some(url("https://github.com/scalatest/scalatestplus-scalacheck")),
@@ -69,7 +69,7 @@ val sharedSettings = Seq(
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   libraryDependencies ++= Seq(
     "org.scalatest" %%% "scalatest-core" % "3.2.18",
-    "org.scalacheck" %%% "scalacheck" % "1.17.0",
+    "org.scalacheck" %%% "scalacheck" % "1.18.0",
     "org.scalatest" %%% "scalatest-shouldmatchers" % "3.2.18" % "test",
     "org.scalatest" %%% "scalatest-funspec" % "3.2.18" % "test",
     "org.scalatest" %%% "scalatest-funsuite" % "3.2.18" % "test"
@@ -174,7 +174,6 @@ lazy val scalatestPlusScalaCheck =
       }
     )
     .nativeSettings(
-      Test / nativeLinkStubs := true,
       Compile / sourceGenerators += {
         Def.task {
           GenResourcesJSVM.genResources((Compile / sourceManaged).value / "org" / "scalatestplus" / "scalacheck", version.value, scalaVersion.value) ++

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,11 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.0.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
 
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.14.0")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.16.0")
 
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % scalaJSVersion)
 
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.16")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 


### PR DESCRIPTION
Bumped up scalacheck version to 1.18, scala-native to 0.5 and scala-js 1.16.