### PR TITLE
Attach a thrown AssertionError as suppressed, not as the cause in property based tests

### DIFF
--- a/scalatestPlusScalaCheck/src/main/scala/org/scalatestplus/scalacheck/CheckerAsserting.scala
+++ b/scalatestPlusScalaCheck/src/main/scala/org/scalatestplus/scalacheck/CheckerAsserting.scala
@@ -112,7 +112,8 @@ abstract class UnitCheckerAsserting {
               args,
               labels,
               None,
-              pos
+              pos,
+              None
             )
 
           case Test.Failed(scalaCheckArgs, scalaCheckLabels) =>
@@ -138,10 +139,16 @@ abstract class UnitCheckerAsserting {
               scalaCheckArgs,
               scalaCheckLabels.toList,
               None,
-              pos
+              pos,
+              None
             )
 
           case Test.PropException(scalaCheckArgs, e, scalaCheckLabels) =>
+
+            // Reporting layers exist that replace the failure they report with any AssertionError
+            // found in its cause chain, which would drop this whole property report. Hand such a
+            // throwable over as suppressed instead, where it cannot outrank the report.
+            val causeWouldOutrankReport = e.isInstanceOf[AssertionError]
 
             indicateFailure(
               sde => FailureMessages.propertyException(prettifier, UnquotedString(e.getClass.getSimpleName)) + "\n" +
@@ -160,8 +167,9 @@ abstract class UnitCheckerAsserting {
               FailureMessages.propertyException(prettifier, UnquotedString(e.getClass.getName)) + prms.initialSeed.map(s => "\n" + FailureMessages.initSeed(prettifier, longSeed(s.toBase64))).getOrElse(""),
               scalaCheckArgs,
               scalaCheckLabels.toList,
-              Some(e),
-              pos
+              if (causeWouldOutrankReport) None else Some(e),
+              pos,
+              if (causeWouldOutrankReport) Some(e) else None
             )
         }
       } else indicateSuccess(FailureMessages.propertyCheckSucceeded())
@@ -169,7 +177,7 @@ abstract class UnitCheckerAsserting {
 
     private[scalacheck] def indicateSuccess(message: => String): Result
 
-    private[scalacheck] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Result
+    private[scalacheck] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position, optionalSuppressed: Option[Throwable]): Result
   }
 
   /**
@@ -182,17 +190,20 @@ abstract class UnitCheckerAsserting {
       type Result = Unit
       def succeed(result: T) = (true, None)
       private[scalacheck] def indicateSuccess(message: => String): Unit = ()
-      private[scalacheck] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Unit = {
-        throw new GeneratorDrivenPropertyCheckFailedException(
-          messageFun,
-          optionalCause,
-          pos,
-          None,
-          undecoratedMessage,
-          scalaCheckArgs,
-          None,
-          scalaCheckLabels.toList
-        )
+      private[scalacheck] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position, optionalSuppressed: Option[Throwable]): Unit = {
+        val ex =
+          new GeneratorDrivenPropertyCheckFailedException(
+            messageFun,
+            optionalCause,
+            pos,
+            None,
+            undecoratedMessage,
+            scalaCheckArgs,
+            None,
+            scalaCheckLabels.toList
+          )
+        optionalSuppressed.foreach(s => ex.addSuppressed(s))
+        throw ex
       }
     }
 }
@@ -208,7 +219,7 @@ abstract class ExpectationCheckerAsserting extends UnitCheckerAsserting {
       type Result = Expectation
       def succeed(result: Expectation) = (result.isYes, result.cause)
       private[scalacheck] def indicateSuccess(message: => String): Expectation = Fact.Yes(message)(prettifier)
-      private[scalacheck] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Expectation = {
+      private[scalacheck] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position, optionalSuppressed: Option[Throwable]): Expectation = {
         val gdpcfe =
           new GeneratorDrivenPropertyCheckFailedException(
             messageFun,
@@ -220,6 +231,7 @@ abstract class ExpectationCheckerAsserting extends UnitCheckerAsserting {
             None,
             scalaCheckLabels.toList
           )
+        optionalSuppressed.foreach(s => gdpcfe.addSuppressed(s))
         val message: String = gdpcfe.getMessage
         Fact.No(message)(prettifier)
       }
@@ -243,17 +255,20 @@ object CheckerAsserting extends ExpectationCheckerAsserting {
       type Result = Assertion
       def succeed(result: Assertion) = (true, None)
       private[scalacheck] def indicateSuccess(message: => String): Assertion = Succeeded
-      private[scalacheck] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position): Assertion = {
-        throw new GeneratorDrivenPropertyCheckFailedException(
-          messageFun,
-          optionalCause,
-          pos,
-          None,
-          undecoratedMessage,
-          scalaCheckArgs,
-          None,
-          scalaCheckLabels.toList
-        )
+      private[scalacheck] def indicateFailure(messageFun: StackDepthException => String, undecoratedMessage: => String, scalaCheckArgs: List[Any], scalaCheckLabels: List[String], optionalCause: Option[Throwable], pos: source.Position, optionalSuppressed: Option[Throwable]): Assertion = {
+        val ex =
+          new GeneratorDrivenPropertyCheckFailedException(
+            messageFun,
+            optionalCause,
+            pos,
+            None,
+            undecoratedMessage,
+            scalaCheckArgs,
+            None,
+            scalaCheckLabels.toList
+          )
+        optionalSuppressed.foreach(s => ex.addSuppressed(s))
+        throw ex
       }
     }
   }

--- a/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/ScalaCheckDrivenPropertyChecksSpec.scala
+++ b/scalatestPlusScalaCheck/src/test/scala/org/scalatest/check/ScalaCheckDrivenPropertyChecksSpec.scala
@@ -42,6 +42,38 @@ class ScalaCheckDrivenPropertyChecksSpec extends funspec.AnyFunSpec with ScalaCh
 
       assert(e.getMessage().contains("List(" + failingList.take(2).mkString(", ") + ", ...)"))
     }
+
+    it("should hand a thrown AssertionError over as suppressed rather than as the cause") {
+      val e =
+        intercept[GeneratorDrivenPropertyCheckFailedException] {
+          forAll { (_: Int) => throw new AssertionError("boom") }
+        }
+
+      assert(e.getCause == null)
+
+      val suppressed = e.getSuppressed
+      assert(suppressed.length == 1)
+      assert(suppressed(0).isInstanceOf[AssertionError])
+      assert(suppressed(0).getMessage == "boom")
+
+      // the report itself must be unaffected
+      assert(e.getMessage.contains("AssertionError was thrown during property evaluation"))
+      assert(e.getMessage.contains("Occurred when passed generated values"))
+      assert(e.getMessage.contains("Init Seed"))
+    }
+
+    it("should still pass a thrown exception that is not an AssertionError as the cause") {
+      val iae = new IllegalArgumentException("boom")
+
+      val e =
+        intercept[GeneratorDrivenPropertyCheckFailedException] {
+          forAll { (_: Int) => throw iae }
+        }
+
+      assert(e.getCause eq iae)
+      assert(e.getSuppressed.isEmpty)
+      assert(e.getMessage.contains("Init Seed"))
+    }
   }
 
 }


### PR DESCRIPTION
 ## Cause

  When a property body throws, `check` reports a `GeneratorDrivenPropertyCheckFailedException` whose
  **message** carries what you need to act on the failure: the shrunk counterexample, the labels and
  `Init Seed:`. The original throwable is passed as that exception's **cause**.

  ## Effect

  Consumers that prefer a cause over the thrown exception lose the whole report. Gradle's
  `DefaultThrowableToTestFailureMapper` walks the cause chain and reports the first `AssertionError` it
  finds, discarding the outer exception without retaining it:

  | body fails via | cause | Gradle reports |
  |---|---|---|
  | `assert`, `shouldBe` | `TestFailedException` (a `RuntimeException`) | full report, seed visible |
  | Akka `expectMsg`, JUnit asserts, `Predef.assert` | `AssertionError` | bare `AssertionError`, **no seed** |

  `assert` survives only because `TestFailedException` extends `RuntimeException`. Had it followed the JVM
  convention for a failed assertion, as this project's own `JUnitTestFailedError` does, every property
  failure would lose its seed.

  ## Fix

  Attach an `AssertionError` as **suppressed** rather than as the **cause**. Wrapping it one level deeper
  would not help, because such consumers walk the whole chain, so it has to leave the chain entirely.
  Nothing is lost: `printStackTrace` prints suppressed throwables with their own stack traces, so the throw
  site inside the property body is still reported.

  `indicateFailure` gains an `optionalSuppressed` parameter. It is `private[scalacheck]`, so this is not a
  public API change. Scoping the change to `AssertionError` keeps `CheckersSpec`'s "thrown exception back as
  the TFE's cause" contract intact, and it matches every type such consumers recognise: opentest4j
  `AssertionFailedError`, `MultipleFailuresError`, `org.junit.ComparisonFailure` and AssertJ's errors all
  extend it.

  `+scalatestPlusScalaCheckJVM/test` is green on 2.12.21, 2.13.18 and 3.3.7 (2079 tests, none changed). Two
  tests are added, one per branch of the predicate. Verified end to end against Gradle 9.6.1: the report and
  `Init Seed` now reach the XML, alongside `Suppressed: java.lang.AssertionError` with its trace.